### PR TITLE
Don not send updated board on start-room event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 require("dotenv").config();
 const io = require("socket.io")(process.env.PORT, {
     serveClient: false,
+    pingInterval: 1000,
 });
 const clone = require("ramda.clone");
 const plakoto = require("./plakoto.js");
@@ -18,7 +19,7 @@ io.on("connection", (socket) => {
         // Generate a random room name string
         const roomName = util.randomAlphanumeric(6);
 
-        // Join ("create") the room
+        // Create ("join") the room
         socket.join(roomName, () => {
             // Leave previous room if already in one
             if (currentRoom && currentRoom.roomName !== roomName) {
@@ -29,14 +30,11 @@ io.on("connection", (socket) => {
             currentRoom = io.sockets.adapter.rooms[roomName];
             currentRoom.roomName = roomName;
 
-            // Initialize a board for the current room
+            // Initialize a game for the current room
             currentRoom.board = plakoto.Board();
             currentRoom.board.initPlakoto();
             currentRoom.boardBackup = clone(currentRoom.board);
             currentRoom.submoves = new Array();
-
-            // Broadcast the board to everyone in the room
-            sendUpdatedBoard(currentRoom.board);
 
             // Send the room name back to the client
             acknowledge({ ok: true, roomName });

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 require("dotenv").config();
 const io = require("socket.io")(process.env.PORT, {
     serveClient: false,
-    pingInterval: 1000,
 });
 const clone = require("ramda.clone");
 const plakoto = require("./plakoto.js");


### PR DESCRIPTION
- Don't send updated board on start-room, which would be redundant since the frontend now starts a room and *then joins it*
- Comment changes for clarity

To merge with https://github.com/michaelti/olympus-backgammon-frontend/pull/21