### PR TITLE
Restrict player actions to the appropriate colour/turn

### DIFF
--- a/src/gameUtil.js
+++ b/src/gameUtil.js
@@ -1,0 +1,6 @@
+// Enum-like object
+exports.Player = Object.freeze({
+    neither: 0,
+    white: 1,
+    black: -1,
+});

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const io = require("socket.io")(process.env.PORT, {
 const clone = require("ramda.clone");
 const plakoto = require("./plakoto.js");
 const util = require("./util.js");
+const gameUtil = require("./gameUtil");
 
 io.on("connection", (socket) => {
     let currentRoom = null;
@@ -22,6 +23,7 @@ io.on("connection", (socket) => {
         socket.join(roomName, () => {
             // Leave previous room if already in one
             if (currentRoom && currentRoom.roomName !== roomName) {
+                if (currentRoom.players) delete currentRoom.players[socket.id];
                 socket.leave(currentRoom.roomName);
             }
 
@@ -35,6 +37,8 @@ io.on("connection", (socket) => {
             currentRoom.boardBackup = clone(currentRoom.board);
             currentRoom.submoves = new Array();
 
+            currentRoom.players = {};
+
             // Send the room name back to the client
             acknowledge({ ok: true, roomName });
         });
@@ -47,6 +51,7 @@ io.on("connection", (socket) => {
             socket.join(roomName, () => {
                 // Leave previous room if already in one
                 if (currentRoom && currentRoom.roomName !== roomName) {
+                    if (currentRoom.players) delete currentRoom.players[socket.id];
                     socket.leave(currentRoom.roomName);
                 }
 
@@ -54,11 +59,21 @@ io.on("connection", (socket) => {
                 currentRoom = io.sockets.adapter.rooms[roomName];
                 currentRoom.roomName = roomName;
 
+                if (!currentRoom.players[socket.id]) {
+                    if (Object.keys(currentRoom.players).length < 2) {
+                        if (!Object.values(currentRoom.players).includes(gameUtil.Player.white)) {
+                            currentRoom.players[socket.id] = gameUtil.Player.white;
+                        } else {
+                            currentRoom.players[socket.id] = gameUtil.Player.black;
+                        }
+                    }
+                }
+
                 // Broadcast the board to everyone in the room
                 sendUpdatedBoard(currentRoom.board);
 
                 // Send the room name back to the client
-                acknowledge({ ok: true, roomName });
+                acknowledge({ ok: true, roomName, player: currentRoom.players[socket.id] });
             });
         } else {
             // Send a failure event back to the client
@@ -71,6 +86,7 @@ io.on("connection", (socket) => {
     // Game event: submove
     socket.on("game/submove", (from, to) => {
         if (!currentRoom) return;
+        if (currentRoom.players[socket.id] !== currentRoom.board.turn) return;
 
         if (currentRoom.board.trySubmove(from, to)) {
             currentRoom.submoves.push(plakoto.Submove(from, to));
@@ -81,6 +97,7 @@ io.on("connection", (socket) => {
     // Game event: apply turn
     socket.on("game/apply-turn", () => {
         if (!currentRoom) return;
+        if (currentRoom.players[socket.id] !== currentRoom.board.turn) return;
 
         /* Validate the whole turn by passing the array of submoves to a method
          * If the move is valid, end the player's turn
@@ -100,6 +117,7 @@ io.on("connection", (socket) => {
     // Game event: undo
     socket.on("game/undo", () => {
         if (!currentRoom) return;
+        if (currentRoom.players[socket.id] !== currentRoom.board.turn) return;
 
         currentRoom.submoves = [];
         currentRoom.board = clone(currentRoom.boardBackup);
@@ -122,6 +140,11 @@ io.on("connection", (socket) => {
 
     // Client disconnecting
     socket.on("disconnecting", () => {
+        // Remove the client from the players object of the current room, if any.
+        if (currentRoom && currentRoom.players) {
+            delete currentRoom.players[socket.id];
+        }
+
         // Log that the client is disconnecting from each room they were in, if any.
         Object.keys(socket.rooms).forEach((roomName) => {
             if (roomName === socket.id) return;

--- a/src/index.js
+++ b/src/index.js
@@ -37,11 +37,8 @@ io.on("connection", (socket) => {
             currentRoom.boardBackup = clone(currentRoom.board);
             currentRoom.submoves = new Array();
 
-<<<<<<< HEAD
             currentRoom.players = {};
 
-=======
->>>>>>> master
             // Send the room name back to the client
             acknowledge({ ok: true, roomName });
         });

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ io.on("connection", (socket) => {
             currentRoom.boardBackup = clone(currentRoom.board);
             currentRoom.submoves = new Array();
 
+            // Initialize a list of players for the current room
             currentRoom.players = {};
 
             // Send the room name back to the client

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ io.on("connection", (socket) => {
         socket.join(roomName, () => {
             // Leave previous room if already in one
             if (currentRoom && currentRoom.roomName !== roomName) {
+                // Remove entry from the players object of the current room, if any.
                 if (currentRoom.players) delete currentRoom.players[socket.id];
                 socket.leave(currentRoom.roomName);
             }
@@ -52,6 +53,7 @@ io.on("connection", (socket) => {
             socket.join(roomName, () => {
                 // Leave previous room if already in one
                 if (currentRoom && currentRoom.roomName !== roomName) {
+                    // Remove entry from the players object of the current room, if any.
                     if (currentRoom.players) delete currentRoom.players[socket.id];
                     socket.leave(currentRoom.roomName);
                 }

--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,7 @@ io.on("connection", (socket) => {
                 currentRoom = io.sockets.adapter.rooms[roomName];
                 currentRoom.roomName = roomName;
 
+                // Add entry to the players list for this room, if there's space.
                 if (!currentRoom.players[socket.id]) {
                     if (Object.keys(currentRoom.players).length < 2) {
                         if (!Object.values(currentRoom.players).includes(gameUtil.Player.white)) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 require("dotenv").config();
 const io = require("socket.io")(process.env.PORT, {
     serveClient: false,
+    pingInterval: 1000,
 });
 const clone = require("ramda.clone");
 const plakoto = require("./plakoto.js");
@@ -18,7 +19,7 @@ io.on("connection", (socket) => {
         // Generate a random room name string
         const roomName = util.randomAlphanumeric(6);
 
-        // Join ("create") the room
+        // Create ("join") the room
         socket.join(roomName, () => {
             // Leave previous room if already in one
             if (currentRoom && currentRoom.roomName !== roomName) {
@@ -29,14 +30,11 @@ io.on("connection", (socket) => {
             currentRoom = io.sockets.adapter.rooms[roomName];
             currentRoom.roomName = roomName;
 
-            // Initialize a board for the current room
+            // Initialize a game for the current room
             currentRoom.board = plakoto.Board();
             currentRoom.board.initPlakoto();
             currentRoom.boardBackup = clone(currentRoom.board);
             currentRoom.submoves = new Array();
-
-            // Broadcast the board to everyone in the room
-            sendUpdatedBoard(currentRoom.board);
 
             // Send the room name back to the client
             acknowledge({ ok: true, roomName });

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 require("dotenv").config();
 const io = require("socket.io")(process.env.PORT, {
     serveClient: false,
-    pingInterval: 1000,
 });
 const clone = require("ramda.clone");
 const plakoto = require("./plakoto.js");

--- a/src/plakoto.js
+++ b/src/plakoto.js
@@ -1,7 +1,5 @@
 const clone = require("ramda.clone");
-const gameUtil = require("./gameUtil");
-
-const Player = gameUtil.Player;
+const Player = require("./gameUtil").Player;
 
 const Pip = (size = 0, owner = Player.neither) => ({
     size: size,

--- a/src/plakoto.js
+++ b/src/plakoto.js
@@ -1,11 +1,7 @@
 const clone = require("ramda.clone");
+const gameUtil = require("./gameUtil");
 
-// Enum-like object
-const Player = Object.freeze({
-    neither: 0,
-    white: 1,
-    black: -1,
-});
+const Player = gameUtil.Player;
 
 const Pip = (size = 0, owner = Player.neither) => ({
     size: size,
@@ -28,7 +24,7 @@ const Board = () => ({
 
     // Initialize the board for a game of plakoto
     initPlakoto() {
-        this.turn = Player.black; // Later, players will roll to see who goes first
+        this.turn = Player.white; // Later, players will roll to see who goes first
         this.rollDice();
         for (let i = 0; i <= 24; i++) {
             this.pips[i] = Pip();


### PR DESCRIPTION
- Each room now has a list of up to 2 players (sockets), colours assigned automatically on join.
- Sockets are restricted to moving, applying, and undoing for their own colour only.
- If both player colours are taken, joining still works leaving you as a non-player (spectator).

You'll see that there's a lot of code repetition starting to happen, so we should work on a little refactor soon.
