### PR TITLE
Keep track of score within a room

### DIFF
--- a/src/gameUtil.js
+++ b/src/gameUtil.js
@@ -39,20 +39,22 @@ exports.Board = () => ({
     },
 
     // Returns the player who's turn it ISN'T
-    otherPlayer() {
-        if (this.turn === Player.black) return Player.white;
-        if (this.turn === Player.white) return Player.black;
+    otherPlayer(player = this.turn) {
+        if (player === Player.black) return Player.white;
+        if (player === Player.white) return Player.black;
         return Player.neither;
     },
 
     // Is the board in a state where either player has won?
+    // Returns the number of points won
     isGameWon() {
         if (this.off[this.turn] === 15) {
             this.winner = this.turn;
             this.turn = Player.neither;
-            return true;
+            // if the other player has born off 0 checkers, return 2 points
+            return this.off[this.otherPlayer(this.winner)] === 0 ? 2 : 1;
         }
-        return false;
+        return 0;
     },
 });
 

--- a/src/listeners/game.js
+++ b/src/listeners/game.js
@@ -30,6 +30,7 @@ module.exports = function (socket, io, rooms = io.sockets.adapter.rooms) {
         if (rooms[socket.currentRoom].board.winner !== null) {
             io.sockets.in(socket.currentRoom).emit("room/update-room", {
                 step: rooms[socket.currentRoom].step,
+                score: rooms[socket.currentRoom].score,
             });
         }
     });

--- a/src/listeners/game.js
+++ b/src/listeners/game.js
@@ -26,7 +26,7 @@ module.exports = function (socket, io, rooms = io.sockets.adapter.rooms) {
             .in(socket.currentRoom)
             .emit("room/update-room", { board: rooms[socket.currentRoom].board });
 
-        // Broadcast the room step if the game has ended
+        // Broadcast the room step and score if the game has ended
         if (rooms[socket.currentRoom].board.winner !== null) {
             io.sockets.in(socket.currentRoom).emit("room/update-room", {
                 step: rooms[socket.currentRoom].step,

--- a/src/listeners/room.js
+++ b/src/listeners/room.js
@@ -60,6 +60,7 @@ module.exports = function (socket, io, rooms = io.sockets.adapter.rooms) {
                 step: rooms[socket.currentRoom].step,
                 dice: rooms[socket.currentRoom].dice,
                 variant: rooms[socket.currentRoom].variant,
+                score: rooms[socket.currentRoom].score,
                 board: rooms[socket.currentRoom].board,
             });
         });

--- a/src/plakoto.js
+++ b/src/plakoto.js
@@ -149,27 +149,34 @@ const Plakoto = () => ({
     },
 
     // Is the board in a state where the game is won?
+    // Returns the number of points won
     isGameWon() {
         const home = { [Player.white]: this.pips[1], [Player.black]: this.pips[24] };
 
         // Both player's starting checkers have been trapped: game is a draw
-        if (this.pips[1].top !== this.pips[1].bot && this.pips[24].top !== this.pips[24].bot)
+        if (this.pips[1].top !== this.pips[1].bot && this.pips[24].top !== this.pips[24].bot) {
             this.winner = Player.neither;
+            this.turn = Player.neither;
+            return 1;
+        }
         // Player has beared off all of their checkers
-        else if (this.off[this.turn] === 15) this.winner = this.turn;
+        else if (this.off[this.turn] === 15) {
+            this.winner = this.turn;
+            this.turn = Player.neither;
+            // if the other player has born off 0 checkers, return 2 points
+            return this.off[this.otherPlayer(this.winner)] === 0 ? 2 : 1;
+        }
         // If other player's starting checker has been pinned and current player's is safe
         else if (
             home[this.otherPlayer()].top !== home[this.otherPlayer()].bot &&
             home[this.turn].bot !== this.turn
         ) {
             this.winner = this.turn;
+            this.turn = Player.neither;
+            return 2;
         }
 
-        if (this.winner !== null) {
-            this.turn = Player.neither;
-            return true;
-        }
-        return false;
+        return 0;
     },
 });
 

--- a/src/roomObj.js
+++ b/src/roomObj.js
@@ -17,6 +17,7 @@ exports.Room = () => ({
     variant: null,
     moves: null,
     players: {},
+    score: { [Player.white]: 0, [Player.black]: 0, [Player.neither]: 0 },
     dice: { [Player.white]: undefined, [Player.black]: undefined, draw: null },
     step: Step.setup,
 
@@ -103,11 +104,14 @@ exports.Room = () => ({
     },
 
     gameApplyTurn() {
+        let points;
         /* Validate the whole turn by passing the array of moves to a method
          * If the turn is valid, end the player's turn
          * Else, return an error and undo the partial turn */
         if (this.boardBackups[0].isTurnValid(this.moves)) {
-            if (this.board.isGameWon()) {
+            points = this.board.isGameWon();
+            if (points) {
+                this.score[this.board.winner] += points;
                 this.step = Step.setup;
             } else {
                 this.board.turn = this.board.otherPlayer();


### PR DESCRIPTION
Games can end with 0, 1, or 2 points.
Score is sent to the frontend on room-join or game end.

This PR must be merged before [frontend #47](https://github.com/michaelti/olympus-backgammon-frontend/pull/47).